### PR TITLE
Run Postgres in a terminal rather than via launchd

### DIFF
--- a/installfest/index.markdown
+++ b/installfest/index.markdown
@@ -150,13 +150,14 @@ Type the following into the terminal:
 createuser -s postgres
 ```
 
-Next type this into the terminal:
+
+Open a new Terminal window and launch Postgres:
 
 ```
-$ launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
-
+postgres -D /usr/local/var/postgres
 ```
 
+When you close this window, Postgres will quit.
 
 
 


### PR DESCRIPTION
Since the intended audience are new and may not code, running Postgres via launchd might be a waste of their resources. This instructions have them running in a terminal window instead.
