### PR TITLE
without parens missing comma

### DIFF
--- a/02_Suggestotron/03-learning-elixir.markdown
+++ b/02_Suggestotron/03-learning-elixir.markdown
@@ -96,11 +96,11 @@ We can check if a value is a float by using the `is_float/1` function.
 The built-in number types have functions we can perform on them as well, such as addition, division, mixing precision, and more.
 
 ```elixir
-iex> 1 + 1 # 2
-iex> div(10, 2)
-iex> rem(10, 3)
+iex> 1 + 1        # 2
+iex> div(10, 2)   # 5
+iex> rem(10, 3)   # 1
 iex> ## Or without parenthesis
-iex> rem 10 3
+iex> rem 10, 3    # 1
 iex> Float.ceil(1.234567, 3) # 1.235
 iex> 10 / 2
 ```


### PR DESCRIPTION
`rem 10 3` produced a syntax error, it needed to be `rem 10,3`
also added comments with expected results for consistency
