### PR TITLE
Hide extra section 3 docs

### DIFF
--- a/03_Chatter/02-add-a-persistence-layer.markdown
+++ b/03_Chatter/02-add-a-persistence-layer.markdown
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Adding a Persistence layer
+published: false
 date: 2016-08-04 23:08:17 -0700
 position: 2
 ---

--- a/03_Chatter/03-add-separate-rooms.markdown
+++ b/03_Chatter/03-add-separate-rooms.markdown
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Multi-Room chat
+published: false	
 date: 2016-08-04 23:08:17 -0700
 position: 3
 ---


### PR DESCRIPTION
Tonight while reviewing tho docs I noticed there is this second section 3 that doesn't really make sense for where it is located. It seems that these docs are additions/improvements to the existing section 3 items. This PR removes them from the navigation so as not to confuse new users as they transition from the intro to the Phoenix project. I have confirmed locally that this works properly and renders the page and subsections correctly:

![hidden_elixir_bridge_nav](https://user-images.githubusercontent.com/1396878/31755814-51686d04-b455-11e7-8828-4b0cd5c9b071.PNG)