### PR TITLE
Configure Git - verify color.ui setting on mac

### DIFF
--- a/01_Installfest/04-install-and-configure-git.markdown
+++ b/01_Installfest/04-install-and-configure-git.markdown
@@ -83,11 +83,6 @@ If on a mac, type this into the terminal
 
 ```
 git config --global color.ui auto
-```
-
-Type this in the terminal:
-
-```
 git config --get color.ui
 ```
 

--- a/01_Installfest/04-install-and-configure-git.markdown
+++ b/01_Installfest/04-install-and-configure-git.markdown
@@ -84,3 +84,14 @@ If on a mac, type this into the terminal
 ```
 git config --global color.ui auto
 ```
+
+Type this in the terminal:
+
+```
+git config --get color.ui
+```
+
+Expected Result:
+```
+auto
+```


### PR DESCRIPTION
## Things Done:
- Updated the Configure git section of installfest, added check for setting `color.ui` to `auto`

Note: A somewhat new-to-programming Elixirbridge attendee wanted to make sure what she entered to set the `color.ui`, did in fact get set.