### PR TITLE
Add Mix information and verification to Elixir install doc.

### DIFF
--- a/01_Installfest/05-install-elixir-and-phoenix.markdown
+++ b/01_Installfest/05-install-elixir-and-phoenix.markdown
@@ -50,6 +50,16 @@ You should see a version number greater than 1.5, like this:
 
 Anything above 1.5 is fine.
 
+Mix is a build tool that ships with Elixir, that provides tasks for creating, compiling, testing your application, managing its dependencies, and more.
+
+To check that Mix is also installed correctly:
+
+`mix -v`
+
+You should see a version number greater than 1.5, like this:
+
+`Mix 1.5.1`
+
 ### Step 7: Install Hex
 
 Type this in the terminal:


### PR DESCRIPTION
## Things Done
- Add blurb about what mix is and how it got installed, to the Elixir install doc. 
- Add verification of Mix's version

Note: During installfest, mix is all of the sudden used with no information. This is just to inform users how it got there, what it is, and how to verify its version.