### PR TITLE
fix typo - Message, limit: limit- to Chatter.Message, limit: limit

### DIFF
--- a/03_Intro_to_Phoenix/02-add-a-perisistence-layer.markdown
+++ b/03_Intro_to_Phoenix/02-add-a-perisistence-layer.markdown
@@ -98,7 +98,7 @@ Since we're going to be getting these messages a lot, it makes sense to put that
 
 ```elixir
 def recent_messages(limit \\ 10) do
-  Chatter.Repo.all(Message, limit: limit)
+  Chatter.Repo.all(Chatter.Message, limit: limit)
 end
 ```
 


### PR DESCRIPTION
Update the reference on the page linked in the chatter tutorial.