### PR TITLE
Fix broken elixirlang links

### DIFF
--- a/02_Intro_to_Elixir/04-elixir-types.markdown
+++ b/02_Intro_to_Elixir/04-elixir-types.markdown
@@ -62,7 +62,7 @@ false
 
 Why is this false? Because 3.14 is not in integer, it's a `Float`. Let's take a look at floats.
 
-> [Docs for Integer](http://elixir-lang.org/docs/stable/elixir/Integer.html)
+> [Docs for Integer](https://hexdocs.pm/elixir/Integer.html)
 
 ### Floats
 
@@ -112,7 +112,7 @@ iex> div(10, 3)
 
 Try some other commands out to see what else you can do.
 
-> [Float docs](http://elixir-lang.org/docs/stable/elixir/Float.html)
+> [Float docs](https://hexdocs.pm/elixir/Float.html)
 
 
 ### Hex, Octal, Binary
@@ -200,7 +200,7 @@ receiver = "World"
 Variables are interpolated using the `#{variable}`
 
 
-More documentation on the [String](http://elixir-lang.org/docs/stable/elixir/String.html) module is available at [http://elixir-lang.org/docs/stable/elixir/String.html](http://elixir-lang.org/docs/stable/elixir/String.html).
+More documentation on the [String](https://hexdocs.pm/elixir/String.html) module is available at [https://hexdocs.pm/elixir/String.html](https://hexdocs.pm/elixir/String.html).
 
 ### Concatenate Operator
 

--- a/02_Intro_to_Elixir/05.7-maps-and-nested-data-structures.markdown
+++ b/02_Intro_to_Elixir/05.7-maps-and-nested-data-structures.markdown
@@ -50,6 +50,6 @@ map = %{:msg => "Hello", "receiver" => :world}
 map.msg
 ```
 
-Check out the [Kernel module](http://elixir-lang.org/docs/stable/elixir/Kernel.html) documentation for more information on other functions available to use when using nested data structures.
+Check out the [Kernel module](https://hexdocs.pm/elixir/Kernel.html) documentation for more information on other functions available to use when using nested data structures.
 
 


### PR DESCRIPTION
This is a more complete PR than #139 , replacing broken elixir-lang links across the documentation with hexdocs.

Didn't do any super thorough checks to make sure I got everything other than the old `ctrl+f`, but this should fix at least a few of the broken intro module links.